### PR TITLE
address: change formatting directive in NewValid

### DIFF
--- a/address.go
+++ b/address.go
@@ -113,7 +113,7 @@ func NewValid(fields ...func(*Address)) (Address, error) {
 	err := Validate(address)
 
 	if err != nil {
-		return address, fmt.Errorf("invalid address: %s", err)
+		return address, fmt.Errorf("invalid address: %w", err)
 	}
 
 	return address, nil

--- a/address_test.go
+++ b/address_test.go
@@ -1,8 +1,11 @@
 package address
 
 import (
+	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 func TestAddressIsZero(t *testing.T) {
@@ -3694,5 +3697,27 @@ func TestGetCountry(t *testing.T) {
 
 	if !reflect.DeepEqual(country, expected) {
 		t.Errorf("Country data for KR does not match expected country data")
+	}
+}
+func TestValidErr(t *testing.T) {
+	_, err := NewValid(
+		WithCountry("AasdgasdgU"), // Must be an ISO 3166-1 country code
+		WithName("John Citizen"),
+		WithOrganization("Some Company Pty Ltd"),
+		WithStreetAddress([]string{
+			"525 Collins Street",
+		}),
+		WithLocality("Melbourasdafsdgne"),
+		WithAdministrativeArea("VIC"), // If the country has a pre-defined list of admin areas (like here), you must use the key and not the name
+		WithPostCode("3000"),
+	)
+	if err != nil {
+		// If there was an error and you want to find out which validations failed,
+		// type switch it as a *multierror.Error to access the list of errors
+		err = errors.Unwrap(err)
+		_, ok := err.(*multierror.Error)
+		if !ok {
+			t.Errorf("Expected a *multierror.Error, got %T", err)
+		}
 	}
 }


### PR DESCRIPTION
to allow for casting to multierror after unwrapping;

test case taken from README which currently will not properly cast;

Currently NewValid when used like in the README (but with an erroneous value) returns an errorstring which is unable to be Unwrapped or cast as a multierror. If we change the formatting directive in NewValid to use `%w` we can then Unwrap the error and cast it as a multierror successfully.