### PR TITLE
[tooling deps] use sub package rather than build tags

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -1,8 +1,0 @@
-//go:build tools
-
-package address
-
-import (
-	_ "github.com/unchartedsoftware/witch"
-	_ "golang.org/x/tools/cmd/stringer"
-)

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,13 @@
+//go:build tools
+
+package tools
+
+import (
+	// Import all required tools so that they can be version controlled via go.mod & go.sum.
+	// These imports are tracked a sub package so as to not impact the dependencies of clients of
+	// the library.
+	// This should be migrated directly to go.mod when the following is complete:
+	// https://github.com/golang/go/issues/48429
+	_ "github.com/unchartedsoftware/witch"
+	_ "golang.org/x/tools/cmd/stringer"
+)


### PR DESCRIPTION
Hi,
Thank you for maintaining this library!

Would y'all be open to using a sub-package rather than build tags for tracking the two tools in `go.mod` rather than via build tags?

I acknowledge that build tags should be more than enough, and they certainly get the job done using the Go toolchain.
My issue is that my employer uses [`Bazel`](https://bazel.build/) with BUILD files (a meta representation of the dependencies and inputs to a package) generated by [`gazelle`](https://github.com/bazelbuild/bazel-gazelle).
Unfortunately, Gazelle does not properly handle the BUILD tags which causes our CI to have issues with this package.

I ran `go mod tidy` and didn't get any diff, so I expect that this should still accomplish the prior purpose of `tools.go`.